### PR TITLE
Fix for deleting all code blocks and config option for min size.

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,5 +1,6 @@
 {
    "server_id": {
+        "blockUploadMinSize": 30,
         "logChannel": "channel_id",
         "whitelist": [
             "application/x-matroska",

--- a/src/listeners/messageListener.js
+++ b/src/listeners/messageListener.js
@@ -29,6 +29,7 @@ export class MessageListener extends Listener {
     const logChannel = config[message.guildId].logChannel;
     const whitelistedMimes = config[message.guildId].whitelist;
     const uploadableMimes = config[message.guildId].uploadableMimes;
+    const blockMinSize = config[message.guildId].blockUploadMinSize;
 
     // handle guild which has not been setup
     if (!config[message.guildId]) {
@@ -55,7 +56,7 @@ export class MessageListener extends Listener {
           let codeArray = block.split("\n");
           codeblocksToBeRemoved.push(block);
 
-          if (codeArray.length >= 20) {
+          if (codeArray.length >= blockMinSize) {
             codeArray.splice(0, 1);
             const formattedCode = codeArray.join("\n");
             const url = await uploadFile(formattedCode);


### PR DESCRIPTION
This adds a new config option named: `blockUploadMinSize`
It is defined inside the config.json file and is per guild. (it's currently set to 30 in the example config).

This also fixes a bug where it was deleting all code blocks.
Now we delete only if an upload has taken place or it isn't an appropriate file type.