### PR TITLE
Fix for resending content with file uploads

### DIFF
--- a/src/listeners/messageListener.js
+++ b/src/listeners/messageListener.js
@@ -154,7 +154,6 @@ export class MessageListener extends Listener {
       }
 
       if (codeBlockUploaded) {
-        finalReplyMessage.push("");
         const fullReplyMessage = finalReplyMessage.join("\n");
         msgChannel.send({
           content: fullReplyMessage,

--- a/src/listeners/messageListener.js
+++ b/src/listeners/messageListener.js
@@ -89,6 +89,12 @@ export class MessageListener extends Listener {
             `**Message text content:** \`\`\`\n${finalMessageContent}\`\`\``
           );
         }
+      } else {
+        if (content.length > 1) {
+          finalReplyMessage.push(
+            `**Message text content:** \`\`\`\n${content}\`\`\``
+          );
+        }
       }
 
       for (const attachment of attachments) {
@@ -148,6 +154,7 @@ export class MessageListener extends Listener {
       }
 
       if (codeBlockUploaded) {
+        finalReplyMessage.push("");
         const fullReplyMessage = finalReplyMessage.join("\n");
         msgChannel.send({
           content: fullReplyMessage,


### PR DESCRIPTION
This fix allows the user to post a message along with a file attachment. 
The message they send will persist and be added to Mime Reply as per the image below. 

![image](https://media.blazebin.net/r/Xg1Hl5.png)